### PR TITLE
fix: stop including test files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "!dist/*.test.*"
   ],
   "scripts": {
     "prepare": "husky install node_modules/@netlify/eslint-config-node/.husky/",


### PR DESCRIPTION
Before:

```
C:\Users\xmr\Desktop\gh-release-fetch>npm pack --dry
npm notice
npm notice package: gh-release-fetch@4.0.3
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 279B  README.md
npm notice 834B  dist/index.d.ts
npm notice 2.5kB dist/index.js
npm notice 11B   dist/index.test.d.ts
npm notice 2.1kB dist/index.test.js
npm notice 2.2kB package.json
npm notice === Tarball Details ===
npm notice name:          gh-release-fetch
npm notice version:       4.0.3
npm notice filename:      gh-release-fetch-4.0.3.tgz
npm notice package size:  3.4 kB
npm notice unpacked size: 9.0 kB
npm notice shasum:        ca13cc4ec8d0a50e9d208e51e3472ea3ec7fa9d8
npm notice integrity:     sha512-vWe9Y/MN/pBtD[...]IOxbZ1sH9mFdQ==
npm notice total files:   7
npm notice
gh-release-fetch-4.0.3.tgz
```

After:

```
C:\Users\xmr\Desktop\gh-release-fetch>npm pack --dry
npm notice
npm notice package: gh-release-fetch@4.0.3
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 279B  README.md
npm notice 834B  dist/index.d.ts
npm notice 2.5kB dist/index.js
npm notice 2.2kB package.json
npm notice === Tarball Details ===
npm notice name:          gh-release-fetch
npm notice version:       4.0.3
npm notice filename:      gh-release-fetch-4.0.3.tgz
npm notice package size:  2.8 kB
npm notice unpacked size: 6.9 kB
npm notice shasum:        b7f83249fb9c115d81fbaa9887dd1eaa172e2f8a
npm notice integrity:     sha512-IM5Imc1ALxB7t[...]YFkKDh2bm+8kQ==
npm notice total files:   5
npm notice
gh-release-fetch-4.0.3.tgz
```